### PR TITLE
#18: remove python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
 language: python
+dist: xenial
 sudo: false
 
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
-  - "3.6-dev" # 3.6 development branch
+  - "3.7"
   - "3.7-dev" # 3.7 development branch
+  - "3.8-dev" # 3.7 development branch
+  - "nightly"
 
 matrix:
   allow_failures:
-    - python: "3.6-dev"
     - python: "3.7-dev"
+    - python: "3.8-dev"
+    - python: "nightly"
 
 services:
   - postgresql


### PR DESCRIPTION
arrow, a cookiecutter python lib dependency stop support against
python 3.4 as this version is over https://www.python.org/dev/peps/pep-0429/
so we are updating travis config according current python versions